### PR TITLE
NGINX Dynamic Module support

### DIFF
--- a/config
+++ b/config
@@ -61,16 +61,7 @@ fi
 
 
 
-if [ $ngx_found = yes ]; then
-    # from: https://github.com/openresty/lua-nginx-module/blob/master/config#L56
-    # this is a hack to persuade nginx's build system to favor
-    # the paths set by our user environments:
-    CFLAGS="$ngx_modsecurity_opt_I $CFLAGS"
-    NGX_LD_OPT="$ngx_modsecurity_opt_L $NGX_LD_OPT"
-
-    CORE_INCS="$CORE_INCS $ngx_feature_path"
-    CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
-else
+if [ $ngx_found = no ]; then
  cat << END
  $0: error: ngx_http_modsecurity requires the ModSecurity library.
 END
@@ -98,8 +89,17 @@ if test -n "$ngx_module_link"; then
             $ngx_addon_dir/src/ngx_http_modsecurity_body_filter.h \
             $ngx_addon_dir/src/ngx_http_modsecurity_log.h \
             "
+        ngx_module_libs="$ngx_feature_libs"
+        ngx_module_incs="$ngx_feature_path"
+
 	. auto/module
 else
+	CFLAGS="$ngx_modsecurity_opt_I $CFLAGS"
+	NGX_LD_OPT="$ngx_modsecurity_opt_L $NGX_LD_OPT"
+
+	CORE_INCS="$CORE_INCS $ngx_feature_path"
+	CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
+
 	HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_modsecurity"
 	NGX_ADDON_SRCS="\
 	    $NGX_ADDON_SRCS \

--- a/config
+++ b/config
@@ -79,24 +79,46 @@ fi
 
 
 ngx_addon_name=ngx_http_modsecurity
-HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_modsecurity"
-NGX_ADDON_SRCS="\
-    $NGX_ADDON_SRCS \
-    $ngx_addon_dir/src/ngx_http_modsecurity_module.c \
-    $ngx_addon_dir/src/ngx_http_modsecurity_pre_access.c \
-    $ngx_addon_dir/src/ngx_http_modsecurity_header_filter.c \
-    $ngx_addon_dir/src/ngx_http_modsecurity_body_filter.c \
-    $ngx_addon_dir/src/ngx_http_modsecurity_log.c \
-    $ngx_addon_dir/src/ngx_http_modsecurity_rewrite.c \
-    "
 
-NGX_ADDON_DEPS="\
-    $NGX_ADDON_DEPS \
-    $ngx_addon_dir/src/ddebug.h \
-    $ngx_addon_dir/src/ngx_http_modsecurity_rewrite.h \
-    $ngx_addon_dir/src/ngx_http_modsecurity_common.h \
-    $ngx_addon_dir/src/ngx_http_modsecurity_pre_access.h \
-    $ngx_addon_dir/src/ngx_http_modsecurity_header_filter.h \
-    $ngx_addon_dir/src/ngx_http_modsecurity_body_filter.h \
-    $ngx_addon_dir/src/ngx_http_modsecurity_log.h \
-    "
+if test -n "$ngx_module_link"; then
+	ngx_module_type=HTTP_AUX_FILTER
+	ngx_module_name=ngx_http_modsecurity
+	ngx_module_srcs="$ngx_addon_dir/src/ngx_http_modsecurity_module.c \
+            $ngx_addon_dir/src/ngx_http_modsecurity_pre_access.c \
+            $ngx_addon_dir/src/ngx_http_modsecurity_header_filter.c \
+            $ngx_addon_dir/src/ngx_http_modsecurity_body_filter.c \
+            $ngx_addon_dir/src/ngx_http_modsecurity_log.c \
+            $ngx_addon_dir/src/ngx_http_modsecurity_rewrite.c \
+            "
+	ngx_module_deps="$ngx_addon_dir/src/ddebug.h \
+            $ngx_addon_dir/src/ngx_http_modsecurity_rewrite.h \
+            $ngx_addon_dir/src/ngx_http_modsecurity_common.h \
+            $ngx_addon_dir/src/ngx_http_modsecurity_pre_access.h \
+            $ngx_addon_dir/src/ngx_http_modsecurity_header_filter.h \
+            $ngx_addon_dir/src/ngx_http_modsecurity_body_filter.h \
+            $ngx_addon_dir/src/ngx_http_modsecurity_log.h \
+            "
+	. auto/module
+else
+	HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_modsecurity"
+	NGX_ADDON_SRCS="\
+	    $NGX_ADDON_SRCS \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_module.c \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_pre_access.c \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_header_filter.c \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_body_filter.c \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_log.c \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_rewrite.c \
+	    "
+
+	NGX_ADDON_DEPS="\
+	    $NGX_ADDON_DEPS \
+	    $ngx_addon_dir/src/ddebug.h \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_rewrite.h \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_common.h \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_pre_access.h \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_header_filter.h \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_body_filter.h \
+	    $ngx_addon_dir/src/ngx_http_modsecurity_log.h \
+	    "
+fi


### PR DESCRIPTION
Lets you compile the module with Dynamic Module in NGINX 1.9.11 onwards.
Simply compile with --add-dynamic-module instead of --add-module and use
the load_module directive in the NGINX configuration file to use.

See:
* https://www.nginx.com/resources/wiki/extending/
* https://www.nginx.com/blog/dynamic-modules-nginx-1-9-11/