### PR TITLE
Extend PCRE malloc/free wrappers to use nginx pools

### DIFF
--- a/src/ngx_http_modsecurity_body_filter.c
+++ b/src/ngx_http_modsecurity_body_filter.c
@@ -146,6 +146,7 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
     if (buffer_fully_loadead == 1)
     {
         int ret;
+        ngx_pool_t *old_pool;
 
         for (chain = in; chain != NULL; chain = chain->next)
         {
@@ -159,9 +160,9 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
             }
         }
 
-        ngx_http_modsecurity_pcre_malloc_init();
+        old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
         msc_process_response_body(ctx->modsec_transaction);
-        ngx_http_modsecurity_pcre_malloc_done();
+        ngx_http_modsecurity_pcre_malloc_done(old_pool);
 
 /* XXX: I don't get how body from modsec being transferred to nginx's buffer.  If so - after adjusting of nginx's
    XXX: body we can proceed to adjust body size (content-length).  see xslt_body_filter() for example */

--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -90,8 +90,8 @@ extern ngx_module_t ngx_http_modsecurity_module;
 int ngx_http_modsecurity_process_intervention (Transaction *transaction, ngx_http_request_t *r);
 ngx_http_modsecurity_ctx_t *ngx_http_modsecurity_create_ctx(ngx_http_request_t *r);
 char *ngx_str_to_char(ngx_str_t a, ngx_pool_t *p);
-void ngx_http_modsecurity_pcre_malloc_init(void);
-void ngx_http_modsecurity_pcre_malloc_done(void);
+ngx_pool_t *ngx_http_modsecurity_pcre_malloc_init(ngx_pool_t *pool);
+void ngx_http_modsecurity_pcre_malloc_done(ngx_pool_t *old_pool);
 
 /* ngx_http_modsecurity_body_filter.c */
 ngx_int_t ngx_http_modsecurity_body_filter_init(void);

--- a/src/ngx_http_modsecurity_header_filter.c
+++ b/src/ngx_http_modsecurity_header_filter.c
@@ -415,6 +415,7 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
     int ret = 0;
     ngx_uint_t status;
     char *http_response_ver;
+    ngx_pool_t *old_pool;
 
 
 /* XXX: if NOT_MODIFIED, do we need to process it at all?  see xslt_header_filter() */
@@ -518,9 +519,9 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
     }
 #endif
 
-    ngx_http_modsecurity_pcre_malloc_init();
+    old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
     msc_process_response_headers(ctx->modsec_transaction, status, http_response_ver);
-    ngx_http_modsecurity_pcre_malloc_done();
+    ngx_http_modsecurity_pcre_malloc_done(old_pool);
     ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r);
     if (ret > 0) {
         return ret;

--- a/src/ngx_http_modsecurity_log.c
+++ b/src/ngx_http_modsecurity_log.c
@@ -37,6 +37,7 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
 {
     ngx_http_modsecurity_ctx_t *ctx = NULL;
     ngx_http_modsecurity_loc_conf_t *cf;
+    ngx_pool_t *old_pool;
 
     dd("catching a new _log_ phase handler");
 
@@ -65,9 +66,9 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
     }
 
     dd("calling msc_process_logging for %p", ctx);
-    ngx_http_modsecurity_pcre_malloc_init();
+    old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
     msc_process_logging(ctx->modsec_transaction);
-    ngx_http_modsecurity_pcre_malloc_done();
+    ngx_http_modsecurity_pcre_malloc_done(old_pool);
 
     return NGX_OK;
 }

--- a/src/ngx_http_modsecurity_pre_access.c
+++ b/src/ngx_http_modsecurity_pre_access.c
@@ -45,6 +45,7 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
 #if 1
     ngx_http_modsecurity_ctx_t *ctx = NULL;
     ngx_http_modsecurity_loc_conf_t *cf;
+    ngx_pool_t *old_pool;
 
     dd("catching a new _preaccess_ phase handler");
 
@@ -194,9 +195,9 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
 
 /* XXX: once more -- is body can be modified ?  content-length need to be adjusted ? */
 
-        ngx_http_modsecurity_pcre_malloc_init();
+        old_pool = ngx_http_modsecurity_pcre_malloc_init(r->pool);
         msc_process_request_body(ctx->modsec_transaction);
-        ngx_http_modsecurity_pcre_malloc_done();
+        ngx_http_modsecurity_pcre_malloc_done(old_pool);
 
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r);
         if (ret > 0) {


### PR DESCRIPTION
The goal is to completely avoid direct malloc()/free() calls from PCRE.

Implementation is heavily based on corresponding parts of the Lua nginx module:
https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_pcrefix.c