### PR TITLE
Fixed memory leak

### DIFF
--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -545,6 +545,7 @@ static void *ngx_http_modsecurity_create_conf(ngx_conf_t *cf)
     conf->enable = NGX_CONF_UNSET;
     conf->sanity_checks_enabled = NGX_CONF_UNSET;
     conf->rules_set = msc_create_rules_set();
+    conf->modsec = NULL;
 
     cln = ngx_pool_cleanup_add(cf->pool, 0);
     if (cln == NULL) {

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -651,9 +651,11 @@ ngx_http_modsecurity_config_cleanup(void *data)
 
     old_pool = ngx_http_modsecurity_pcre_malloc_init(NULL);
     msc_rules_cleanup(t->rules_set);
+    msc_cleanup(t->modsec);
     ngx_http_modsecurity_pcre_malloc_done(old_pool);
 
     t->rules_set = NULL;
+    t->modsec = NULL;
 }
 
 


### PR DESCRIPTION
I compiled the nginx-connector with the flag "-fsanitize=leak" and found that the "ModSecurity" object from the "ngx_http_modsecurity_conf_t" structure is not freed.

I tried to fix it according to the examples.