### PR TITLE
The pool pointer is now available for ngx_http_modsecurity_config_cleanup

### DIFF
--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -93,6 +93,8 @@ typedef struct {
     ngx_flag_t sanity_checks_enabled;
 
     Rules *rules_set;
+
+    void *pool;
 } ngx_http_modsecurity_conf_t;
 
 

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -554,6 +554,7 @@ static void *ngx_http_modsecurity_create_conf(ngx_conf_t *cf)
     conf->sanity_checks_enabled = NGX_CONF_UNSET;
     conf->rules_set = msc_create_rules_set();
     conf->modsec = NULL;
+    conf->pool = cf->pool;
 
     cln = ngx_pool_cleanup_add(cf->pool, 0);
     if (cln == NULL) {
@@ -658,7 +659,7 @@ ngx_http_modsecurity_config_cleanup(void *data)
 
     dd("deleting a loc conf -- RuleSet is: \"%p\"", t->rules_set);
 
-    old_pool = ngx_http_modsecurity_pcre_malloc_init(NULL);
+    old_pool = ngx_http_modsecurity_pcre_malloc_init(t->pool);
     msc_rules_cleanup(t->rules_set);
     msc_cleanup(t->modsec);
     ngx_http_modsecurity_pcre_malloc_done(old_pool);


### PR DESCRIPTION
I did a little research and found out that the rules that are initialized in the pool by the `msc_rules_add_file` or `msc_rules_add` can not be freed by the `msc_rules_cleanup` because `ngx_http_modsecurity_config_cleanup` does not know anything about this pool (since it is NULL).