### PR TITLE
Emit connector version in error log

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
-DD mmm YYYY  - 1.0.0
+
+v1.0.0 - 2017-Dec-20
 --------------------
 
- * First version of the ModSecurity-nginx 
-   [Felipe Zimmerle]
+ - First version of ModSecurity-nginx connector
+

--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -26,6 +26,34 @@
 #include <modsecurity/transaction.h>
 #include <modsecurity/rules.h>
 
+
+/**
+ * TAG_NUM:
+ *
+ * Alpha  - 001
+ * Beta   - 002
+ * Dev    - 010
+ * Rc1    - 051
+ * Rc2    - 052
+ * ...    - ...
+ * Release- 100
+ *
+ */
+
+#define MODSECURITY_NGINX_MAJOR "1"
+#define MODSECURITY_NGINX_MINOR "0"
+#define MODSECURITY_NGINX_PATCHLEVEL "0"
+#define MODSECURITY_NGINX_TAG ""
+#define MODSECURITY_NGINX_TAG_NUM "100"
+
+#define MODSECURITY_NGINX_VERSION MODSECURITY_NGINX_MAJOR "." \
+    MODSECURITY_NGINX_MINOR "." MODSECURITY_NGINX_PATCHLEVEL \
+    MODSECURITY_NGINX_TAG
+
+#define MODSECURITY_NGINX_VERSION_NUM MODSECURITY_NGINX_MAJOR \
+    MODSECURITY_NGINX_MINOR MODSECURITY_NGINX_PATCHLEVEL \
+    MODSECURITY_NGINX_TAG_NUM
+
 typedef struct {
     ngx_str_t name;
     ngx_str_t value;

--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -54,6 +54,9 @@
     MODSECURITY_NGINX_MINOR MODSECURITY_NGINX_PATCHLEVEL \
     MODSECURITY_NGINX_TAG_NUM
 
+#define MODSECURITY_NGINX_WHOAMI "ModSecurity-nginx v" \
+    MODSECURITY_NGINX_VERSION
+
 typedef struct {
     ngx_str_t name;
     ngx_str_t value;

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -496,6 +496,8 @@ ngx_http_modsecurity_create_main_conf(ngx_conf_t *cf)
 {
     ngx_http_modsecurity_conf_t *conf;
 
+    ngx_log_error(NGX_LOG_NOTICE, cf->log, 0, MODSECURITY_NGINX_WHOAMI);
+
     /* ngx_pcalloc already sets all of this scructure to zeros. */
     conf = ngx_http_modsecurity_create_conf(cf);
 
@@ -515,7 +517,7 @@ ngx_http_modsecurity_create_main_conf(ngx_conf_t *cf)
     }
 
     /* Provide our connector information to LibModSecurity */
-    msc_set_connector_info(conf->modsec, "ModSecurity-nginx v0.1.1-beta");
+    msc_set_connector_info(conf->modsec, MODSECURITY_NGINX_WHOAMI);
     msc_set_log_cb(conf->modsec, ngx_http_modsecurity_log);
 
     return conf;


### PR DESCRIPTION
Also, use the same string in `msc_set_connector_info()`.

Ideally, "banner" should be printed in init module function [1], but in this case it won't appear if there are errors in ModSecurity configuration (evaluated by `msc_init()`), therefore I decided to put it into earlier configuration creation phase.

Example log (valid configuration):

```
root@vagrant:/# nginx
root@vagrant:/# cat /var/log/nginx/error.log 
2017/12/25 09:38:30 [notice] 13364#13364: ModSecurity-nginx v1.0.0
2017/12/25 09:38:30 [notice] 13364#13364: using the "epoll" event method
2017/12/25 09:38:30 [notice] 13364#13364: nginx/1.13.7
2017/12/25 09:38:30 [notice] 13364#13364: built by gcc 6.3.0 20170406 (Ubuntu 6.3.0-12ubuntu2) 
2017/12/25 09:38:30 [notice] 13364#13364: OS: Linux 4.10.0-30-generic
2017/12/25 09:38:30 [notice] 13364#13364: getrlimit(RLIMIT_NOFILE): 131072:131072
2017/12/25 09:38:30 [notice] 13365#13365: start worker processes
2017/12/25 09:38:30 [notice] 13365#13365: start worker process 13366
```

Example log (invalid configuration):

```
root@vagrant:/# nginx
nginx: [emerg] "modsecurity_rules_file" directive Rules error. File: /etc/nginx/modsec/modsecurity.conf. Line: 1. Column: 25. Invalid input:  NonexistentDirective 123 in /etc/nginx/nginx.conf:75
root@vagrant:/# cat /var/log/nginx/error.log 
2017/12/25 09:39:34 [notice] 13373#13373: ModSecurity-nginx v1.0.0
2017/12/25 09:39:34 [emerg] 13373#13373: "modsecurity_rules_file" directive Rules error. File: /etc/nginx/modsec/modsecurity.conf. Line: 1. Column: 25. Invalid input:  NonexistentDirective 123 in /etc/nginx/nginx.conf:75
```

[1] http://nginx.org/en/docs/dev/development_guide.html#core_modules