### PR TITLE
Fixed processing of response body chunks ...

### DIFF
--- a/src/ngx_http_modsecurity_body_filter.c
+++ b/src/ngx_http_modsecurity_body_filter.c
@@ -150,9 +150,9 @@ ngx_http_modsecurity_body_filter(ngx_http_request_t *r, ngx_chain_t *in)
 
         for (chain = in; chain != NULL; chain = chain->next)
         {
-            u_char *data = chain->buf->start;
+            u_char *data = chain->buf->pos;
 
-            msc_append_response_body(ctx->modsec_transaction, data, chain->buf->end - data);
+            msc_append_response_body(ctx->modsec_transaction, data, chain->buf->last - data);
             ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r);
             if (ret > 0) {
                 return ngx_http_filter_finalize_request(r,

--- a/src/ngx_http_modsecurity_pre_access.c
+++ b/src/ngx_http_modsecurity_pre_access.c
@@ -163,10 +163,10 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
 
         while (chain && !already_inspected)
         {
-            u_char *data = chain->buf->start;
+            u_char *data = chain->buf->pos;
 
             msc_append_request_body(ctx->modsec_transaction, data,
-                chain->buf->last - chain->buf->pos);
+                chain->buf->last - data);
 
             if (chain->buf->last_buf) {
                 break;


### PR DESCRIPTION
in ngx_http_modsecurity_body_filter.

A body filter function (ngx_http_modsecurity_body_filter in our case) can be
called by Nginx several times during request processing. And each time with
it own unique set of chained buf pointers.

For example, suppose a complete response consists of this chain of data:
    A->B->C->D->E
Ngix may (and actually does, as verified by me in gdb) call body filter two
times like this:
    handler(r, in = A->B->C)
    handler(r, in = D->E), E has last_buf set

Current implementation delays feeding chain->buf to msc_append_response_body
until it comes upon a chain with buf->last_buf set. So we loose chain containing
A->B->C sequence. We must process body bufs as soon as we see them in body
handler otherwise we will not see them again.

N.B. You have PR #84 pending. It goes further and fixes the problem when
a blocking decision is made after headers were sent. I intentionally retained
current (buggy) behavior to make my patch less intrusive and easier to review.
Besides #84 impose an excessive memory usage due to a complete copy of all
bufs passed through body filter (we have sometimes 500K and more replies in our
applications) - I will elaborate on this in code review for #84.

This PR depends on #104 