### PR TITLE
Increase log level for disruptive actions to error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 v1.0.x - YYYY-MMM-DD (To be released)
 -------------------------------------
+ - Increase log level for disruptive actions to "error"
+   [Issue #112 - @victorhora ]
  - Fix processing of response body when gzip compression is enabled
    [Issue #107 - @turchanov]
  - Fixed processing of response body chunks in

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -151,7 +151,7 @@ ngx_http_modsecurity_process_intervention (Transaction *transaction, ngx_http_re
         log = "(no log message was specified)";
     }
 
-    ngx_log_error(NGX_LOG_WARN, (ngx_log_t *)r->connection->log, 0, "%s", log);
+    ngx_log_error(NGX_LOG_ERR, (ngx_log_t *)r->connection->log, 0, "%s", log);
 
     if (intervention.log != NULL) {
         free(intervention.log);


### PR DESCRIPTION
This pull request is intended to change the log level from _warn_ to the "default" of _error_ when writing log entries of disruptive actions on Nginx [error_log](https://nginx.org/en/docs/ngx_core_module.html#error_log).

I've noticed this would be contradictory to @defanator's commit https://github.com/SpiderLabs/ModSecurity-nginx/commit/b51e555d39337637f8be8c5e16dbfb28b385088a which although it seems technically accurate it seems like it was getting some users a bit confused of why they were not getting ModSecurity logs on Nginx by default. This is intended to resolve issue https://github.com/SpiderLabs/ModSecurity-nginx/issues/112

