### PR TITLE
Avoid processing of subrequests initiated by the error_page

### DIFF
--- a/src/ngx_http_modsecurity_header_filter.c
+++ b/src/ngx_http_modsecurity_header_filter.c
@@ -420,6 +420,10 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
 
 /* XXX: if NOT_MODIFIED, do we need to process it at all?  see xslt_header_filter() */
 
+    if (r->error_page) {
+        return ngx_http_next_header_filter(r);
+    }
+
     ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity_module);
 
     dd("header filter, recovering ctx: %p", ctx);

--- a/src/ngx_http_modsecurity_log.c
+++ b/src/ngx_http_modsecurity_log.c
@@ -41,6 +41,10 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
     ngx_http_modsecurity_ctx_t   *ctx;
     ngx_http_modsecurity_conf_t  *mcf;
 
+    if (r->error_page) {
+        return NGX_OK;
+    }
+
     dd("catching a new _log_ phase handler");
 
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);

--- a/src/ngx_http_modsecurity_pre_access.c
+++ b/src/ngx_http_modsecurity_pre_access.c
@@ -48,6 +48,10 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
     ngx_http_modsecurity_ctx_t   *ctx;
     ngx_http_modsecurity_conf_t  *mcf;
 
+    if (r->error_page) {
+        return NGX_DECLINED;
+    }
+
     dd("catching a new _preaccess_ phase handler");
 
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);

--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -27,6 +27,10 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
     ngx_http_modsecurity_ctx_t   *ctx;
     ngx_http_modsecurity_conf_t  *mcf;
 
+    if (r->error_page) {
+        return NGX_DECLINED;
+    }
+
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
     if (mcf == NULL || mcf->enable != 1) {
         dd("ModSecurity not enabled... returning");


### PR DESCRIPTION
Closes #164, SpiderLabs/ModSecurity#2143.

Needs more investigation about possible effect on https://github.com/SpiderLabs/ModSecurity-nginx/issues/76 as well.