### PR TITLE
Fix audit_log not generated for disruptive actions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v1.0.x - YYYY-MMM-DD (To be released)
 -------------------------------------
 
+ - Fix audit_log not generated for disruptive actions 
+   [Issue #170, #2220, #2237 - @victorhora]
  - Exit more gracefully if uri length is zero
    [@martinhsv]
 

--- a/src/ngx_http_modsecurity_header_filter.c
+++ b/src/ngx_http_modsecurity_header_filter.c
@@ -420,10 +420,6 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
 
 /* XXX: if NOT_MODIFIED, do we need to process it at all?  see xslt_header_filter() */
 
-    if (r->error_page) {
-        return ngx_http_next_header_filter(r);
-    }
-
     ctx = ngx_http_get_module_ctx(r, ngx_http_modsecurity_module);
 
     dd("header filter, recovering ctx: %p", ctx);
@@ -527,6 +523,9 @@ ngx_http_modsecurity_header_filter(ngx_http_request_t *r)
     msc_process_response_headers(ctx->modsec_transaction, status, http_response_ver);
     ngx_http_modsecurity_pcre_malloc_done(old_pool);
     ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r);
+    if (r->error_page) {
+        return ngx_http_next_header_filter(r);
+        }
     if (ret > 0) {
         return ret;
     }

--- a/src/ngx_http_modsecurity_log.c
+++ b/src/ngx_http_modsecurity_log.c
@@ -41,10 +41,6 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
     ngx_http_modsecurity_ctx_t   *ctx;
     ngx_http_modsecurity_conf_t  *mcf;
 
-    if (r->error_page) {
-        return NGX_OK;
-    }
-
     dd("catching a new _log_ phase handler");
 
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);

--- a/src/ngx_http_modsecurity_pre_access.c
+++ b/src/ngx_http_modsecurity_pre_access.c
@@ -48,10 +48,6 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
     ngx_http_modsecurity_ctx_t   *ctx;
     ngx_http_modsecurity_conf_t  *mcf;
 
-    if (r->error_page) {
-        return NGX_DECLINED;
-    }
-
     dd("catching a new _preaccess_ phase handler");
 
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
@@ -207,6 +203,9 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
         ngx_http_modsecurity_pcre_malloc_done(old_pool);
 
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r);
+        if (r->error_page) {
+            return NGX_DECLINED;
+            }
         if (ret > 0) {
             return ret;
         }

--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -27,10 +27,6 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
     ngx_http_modsecurity_ctx_t   *ctx;
     ngx_http_modsecurity_conf_t  *mcf;
 
-    if (r->error_page) {
-        return NGX_DECLINED;
-    }
-
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
     if (mcf == NULL || mcf->enable != 1) {
         dd("ModSecurity not enabled... returning");
@@ -204,6 +200,9 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
         ngx_http_modsecurity_pcre_malloc_done(old_pool);
         dd("Processing intervention with the request headers information filled in");
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r);
+        if (r->error_page) {
+            return NGX_DECLINED;
+            }
         if (ret > 0) {
             return ret;
         }


### PR DESCRIPTION
PR intended to fix issues #170, SpiderLabs/ModSecurity/issues/2220 and SpiderLabs/ModSecurity/issues/2237 where the audit_log audit_log not generated for disruptive actions.

This changes commit https://github.com/SpiderLabs/ModSecurity-nginx/commit/baef88aac6c1eb3c132494f405a10166cbb50d6e that fixes the custom error pages issue (SpiderLabs/ModSecurity#2143) but it seemed to be returning too early not allowing the audit_logs to be generated on all phases.