### PR TITLE
Add support to 'nostale' for GitHub Actions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,5 +14,6 @@ jobs:
         stale-pr-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
+        exempt-issue-label: 'nostale'
         days-before-stale: 30
         days-before-close: 5


### PR DESCRIPTION
Minor change to support an additional tag "nostale" for issues that shouldn't be closed automatically by the GitHub Actions bot: https://github.com/actions/stale/pull/11