### PR TITLE
Support audit log rotation on SIGHUP and SIGUSR1

### DIFF
--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -106,6 +106,7 @@ typedef struct {
     ngx_uint_t                 rules_inline;
     ngx_uint_t                 rules_file;
     ngx_uint_t                 rules_remote;
+    ngx_open_file_t           *audit_log_reopen;
 } ngx_http_modsecurity_main_conf_t;
 
 


### PR DESCRIPTION
This is a PR that uses SpiderLabs/ModSecurity#2304 to support audit log rotation when nginx reloads config or reopens log files.

Thanks to @defanator for [providing a proof-of-concept](https://github.com/SpiderLabs/ModSecurity-nginx/issues/121#issuecomment-442416602)!

I tested this by:
1. Using `lsof` to observe nginx has the audit log open
1. Moving the audit log file
1. Using `lsof` to confirm the nginx now references the moved file
1. Signaling the nginx master process with SIGHUP or SIGUSR1.
1. Testing the same things with `nginx -s reload` and `nginx -s reopen`

When I wasn't convinced of the thread-safety of audit log writes and log reopen within nginx, I also attempted to test it with the following script using GNU parallel:
`parallel -j+0 ./test-reopen.sh ::: {1..10000}`

```bash
#!/bin/bash

set -euo pipefail

read s < /dev/urandom
TEST=$(( ${#s} % 11 ))

if [[ TEST -eq 0 ]]; then
	echo "$1 reopen with SIGUSR1"
	kill -USR1 "$(pgrep -P1 nginx)"
elif [[ TEST -eq 1 ]]; then
	echo "$1 reload with SIGHUP"
	kill -HUP "$(pgrep -P1 nginx)"
else
	echo "$1 triggering modsec logging"
	# Matches a silly rule created for testing
	curl --silent http://localhost/index.html?asdf 2>&1 >/dev/null &
fi

pgrep -d", " nginx
```

This test didn't hurt, but due to nginx's primarily single-threaded architecture, I believe log reopen is thread-safe here by default.

resolves #121 