### PR TITLE
Fix error_page internal redirect false positive logging

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,10 @@
 v1.0.x - YYYY-MMM-DD (To be released)
 -------------------------------------
-
+ - Fix request logging false positives due to error_page internal redirects
+   [Issue #182 - @jeremyjpj0916]
  - Fix config setting not respected: client_body_in_file_only on
    [Issue #187 - @martinhsv]
- - Fix audit_log not generated for disruptive actions 
+ - Fix audit_log not generated for disruptive actions
    [Issue #170, #2220, #2237 - @victorhora]
  - Exit more gracefully if uri length is zero
    [@martinhsv]
@@ -13,7 +14,7 @@ v1.0.1 - 2019-Dec-16
 
  - Fixed obtaining of server_addr
    [Issue #167, #168 - @defanator]
- - Avoid processing of subrequests initiated by the error_page 
+ - Avoid processing of subrequests initiated by the error_page
    [Issue #76, #164, #165 - @defanator]
  - Tests: extend request body tests
    [Issue #142,#143 - @defanator]
@@ -53,4 +54,3 @@ v1.0.0 - 2017-Dec-20
 --------------------
 
  - First version of ModSecurity-nginx connector
-

--- a/src/ngx_http_modsecurity_pre_access.c
+++ b/src/ngx_http_modsecurity_pre_access.c
@@ -48,6 +48,10 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
     ngx_http_modsecurity_ctx_t   *ctx;
     ngx_http_modsecurity_conf_t  *mcf;
 
+    if (r->error_page) {
+        return NGX_DECLINED;
+    }
+
     dd("catching a new _preaccess_ phase handler");
 
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
@@ -202,9 +206,6 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
         ngx_http_modsecurity_pcre_malloc_done(old_pool);
 
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r);
-        if (r->error_page) {
-            return NGX_DECLINED;
-            }
         if (ret > 0) {
             return ret;
         }
@@ -214,4 +215,3 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
 #endif
     return NGX_DECLINED;
 }
-

--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -27,6 +27,10 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
     ngx_http_modsecurity_ctx_t   *ctx;
     ngx_http_modsecurity_conf_t  *mcf;
 
+    if (r->error_page) {
+        return NGX_DECLINED;
+    }
+
     mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
     if (mcf == NULL || mcf->enable != 1) {
         dd("ModSecurity not enabled... returning");
@@ -204,9 +208,6 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
         ngx_http_modsecurity_pcre_malloc_done(old_pool);
         dd("Processing intervention with the request headers information filled in");
         ret = ngx_http_modsecurity_process_intervention(ctx->modsec_transaction, r);
-        if (r->error_page) {
-            return NGX_DECLINED;
-            }
         if (ret > 0) {
             return ret;
         }


### PR DESCRIPTION
Fixes: #182 

Problem here was ```error_page``` redirects don't maintain original client request data. Hence ModSecurity has false information when evaluating the clients HTTP request a second time around during the request(HTTP Method Header is always reset to GET, URI is also not the original from client request). It is also inefficient to evaluate the request data a second time around after the internal redirect, hence cutting out those phases the second time around after the redirect makes sense and is a performance improvement.

To figure it out I was reviewing prior commits, specifically:

https://github.com/SpiderLabs/ModSecurity-nginx/commit/ce1d438bc665c28853eb5b429aad515d42027919

Which regarding this commit did indeed ensure the log phase still runs during ```error_page``` internal redirect, but just had not considered the implications of re-processing the NGX request phases(phases prior to the ```proxy_pass``` directive for instance) again.


Currently running these changes in our dev and stage environments personally. Will be pushing to our prod in the next week or so, will run as a fork until this is merged.