### PR TITLE
Fix nginx not clearing body cache (caused by incomplete fix for #187)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v1.0.x - YYYY-MMM-DD (To be released)
 -------------------------------------
 
+ - Fix nginx not clearing body cache (caused by incomplete fix for #187)
+   [Issue #216 - @krewi1, @martinhsv]
  - Fix config setting not respected: client_body_in_file_only on
    [Issue #187 - @martinhsv]
  - Fix audit_log not generated for disruptive actions 

--- a/src/ngx_http_modsecurity_pre_access.c
+++ b/src/ngx_http_modsecurity_pre_access.c
@@ -104,6 +104,13 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
          */
         r->request_body_in_single_buf = 1;
         r->request_body_in_persistent_file = 1;
+        if (!r->request_body_in_file_only) {
+            // If the above condition fails, then the flag below will have been
+            // set correctly elsewhere. We need to set the flag here for other
+            // conditions (client_body_in_file_only not used but
+            // client_body_buffer_size is)
+            r->request_body_in_clean_file = 1;
+        }
 
         rc = ngx_http_read_client_request_body(r,
             ngx_http_modsecurity_request_read);


### PR DESCRIPTION
Issue 187 described a problem where the configuration setting 'client_body_in_file_only on' was not respected -- i.e. the body files were deleted despite the setting stating the file should be retained.

The original fix was to simply remove the setting of the flag in this function.  This caused a side effect if no 'client_body_in_file_only' was being used, but body content was written to disk for other reasons (in this case, for exceeding client_body_buffer_size).  In this case files were incorrectly retained.

The fix here is to restore the setting of 'r->request_body_in_clean_file', but to only execute it for the needed conditions.

Closes #216 