### PR TITLE
Support http protocol versions besides 0.9, 1.0, 1.1, 2.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 v1.0.x - YYYY-MMM-DD (To be released)
 -------------------------------------
 
+ - Support http protocol versions besides 0.9, 1.0, 1.1, 2.0
+   [Issue #224 - @HQuest, @martinhsv]
  - Fix nginx not clearing body cache (caused by incomplete fix for #187)
    [Issue #216 - @krewi1, @martinhsv]
  - Fix config setting not respected: client_body_in_file_only on

--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -137,7 +137,15 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
                 break;
 #endif
             default :
-                http_version = "1.0";
+                http_version = ngx_str_to_char(r->http_protocol, r->pool);
+                if (http_version == (char*)-1) {
+                    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+                }
+                if ((http_version != NULL) && (strlen(http_version) > 5) && (!strncmp("HTTP/", http_version, 5))) {
+                    http_version += 5;
+                } else {
+                    http_version = "1.0";
+                }
                 break;
         }
 


### PR DESCRIPTION
This pull request was prompted by https://github.com/SpiderLabs/ModSecurity/issues/2380.

Until this change, any HTTP protocol version other than 0.9, 1.0, 1.1, and 2.0 would actually result in the ModSecurity-nginx connector passing a value of "1.0" to ModSecurity's msc_process_uri function.

With this change, any characters following the five-character 'HTTP/' protocol prefix will get passed to ModSecurity, as long as nginx has successfully populated ngx_http_request_t->http_protocol.
