### PR TITLE
Restore method name for error_page in audit log

### DIFF
--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -143,7 +143,17 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
         }
 
         const char *n_uri = ngx_str_to_char(r->unparsed_uri, r->pool);
-        const char *n_method = ngx_str_to_char(r->method_name, r->pool);
+        const char *n_method = ngx_str_to_char(r->request_line, r->pool);
+        if (n_method != NULL && n_method != (char *)-1) {
+            char *p = (char *) n_method;
+            while (*p) {
+                if (*p == ' ') {
+                    *p = '\0';
+                    break;
+                }
+                p++;
+            }
+        }
         if (n_uri == (char*)-1 || n_method == (char*)-1) {
             return NGX_HTTP_INTERNAL_SERVER_ERROR;
         }


### PR DESCRIPTION
Nginx handles `error_page` via `ngx_http_internal_redirect`, and audit log in `ModSecurity-nginx` is trigged in the next handler.

In nginx's code, it's harded to `GET` for non-`HEAD`, refers https://github.com/nginx/nginx/blob/master/src/http/ngx_http_special_response.c#L618-L621:

```c
        if (r->method != NGX_HTTP_HEAD) {
            r->method = NGX_HTTP_GET;
            r->method_name = ngx_http_core_get_method;
        }
```

This patch use `method_name` from `request_line` to fix this issue.

This should fix method name in https://github.com/SpiderLabs/ModSecurity-nginx/issues/182, and solve https://github.com/SpiderLabs/ModSecurity-nginx/issues/258.