### PR TITLE
terminated for status 101 (like websocket)

### DIFF
--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -142,6 +142,7 @@ ngx_http_modsecurity_ctx_t *ngx_http_modsecurity_create_ctx(ngx_http_request_t *
 char *ngx_str_to_char(ngx_str_t a, ngx_pool_t *p);
 ngx_pool_t *ngx_http_modsecurity_pcre_malloc_init(ngx_pool_t *pool);
 void ngx_http_modsecurity_pcre_malloc_done(ngx_pool_t *old_pool);
+void ngx_http_modsecurity_cleanup(void *data);
 
 /* ngx_http_modsecurity_body_filter.c */
 ngx_int_t ngx_http_modsecurity_body_filter_init(void);

--- a/src/ngx_http_modsecurity_module.c
+++ b/src/ngx_http_modsecurity_module.c
@@ -240,7 +240,12 @@ ngx_http_modsecurity_cleanup(void *data)
 
     ctx = (ngx_http_modsecurity_ctx_t *) data;
 
+    if (!ctx->modsec_transaction) {
+        // it's already clean in 101
+        return;
+    }
     msc_transaction_cleanup(ctx->modsec_transaction);
+    ctx->modsec_transaction = NULL;
 
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
     /*


### PR DESCRIPTION
If server responsed 101, it will switch to other tcp protocol.
There is no http request / response any more.

This patch will free transaction when received status 101.
Nginx will free the ctx when connection terminates.