### PR TITLE
Add editorconfig to help OSS contributors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+end_of_line = lf
+indent_style = space
+indent_size = 4
+


### PR DESCRIPTION
When switching between many different open source code bases, it can be cumbersome to constantly change editor settings in order to respect a given project's basic style preferences. EditorConfig is a popular format for representing those preferences so editors can automatically respect them.

Many editors support EditorConfig out of the box, and many others have EditorConfig plugins:
https://editorconfig.org/#pre-installed

This commit adds a simple EditorConfig for ModSecurity-nginx.