### PR TITLE
Allow enabling modsecurity per request

### DIFF
--- a/src/ngx_http_modsecurity_common.h
+++ b/src/ngx_http_modsecurity_common.h
@@ -116,7 +116,7 @@ typedef struct {
     /* RulesSet or Rules */
     void                      *rules_set;
 
-    ngx_flag_t                 enable;
+    ngx_http_complex_value_t  *enable;
 #if defined(MODSECURITY_SANITY_CHECKS) && (MODSECURITY_SANITY_CHECKS)
     ngx_flag_t                 sanity_checks_enabled;
 #endif
@@ -147,6 +147,8 @@ char *ngx_str_to_char(ngx_str_t a, ngx_pool_t *p);
 ngx_pool_t *ngx_http_modsecurity_pcre_malloc_init(ngx_pool_t *pool);
 void ngx_http_modsecurity_pcre_malloc_done(ngx_pool_t *old_pool);
 #endif
+
+ngx_int_t ngx_http_modsecurity_is_enabled(ngx_http_request_t *r);
 
 /* ngx_http_modsecurity_body_filter.c */
 ngx_int_t ngx_http_modsecurity_body_filter_init(void);

--- a/src/ngx_http_modsecurity_log.c
+++ b/src/ngx_http_modsecurity_log.c
@@ -39,12 +39,10 @@ ngx_http_modsecurity_log_handler(ngx_http_request_t *r)
 {
     ngx_pool_t                   *old_pool;
     ngx_http_modsecurity_ctx_t   *ctx;
-    ngx_http_modsecurity_conf_t  *mcf;
 
     dd("catching a new _log_ phase handler");
 
-    mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
-    if (mcf == NULL || mcf->enable != 1)
+    if (ngx_http_modsecurity_is_enabled(r) != NGX_OK)
     {
         dd("ModSecurity not enabled... returning");
         return NGX_OK;

--- a/src/ngx_http_modsecurity_pre_access.c
+++ b/src/ngx_http_modsecurity_pre_access.c
@@ -46,12 +46,10 @@ ngx_http_modsecurity_pre_access_handler(ngx_http_request_t *r)
 #if 1
     ngx_pool_t                   *old_pool;
     ngx_http_modsecurity_ctx_t   *ctx;
-    ngx_http_modsecurity_conf_t  *mcf;
 
     dd("catching a new _preaccess_ phase handler");
 
-    mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
-    if (mcf == NULL || mcf->enable != 1)
+    if (ngx_http_modsecurity_is_enabled(r) != NGX_OK)
     {
         dd("ModSecurity not enabled... returning");
         return NGX_DECLINED;

--- a/src/ngx_http_modsecurity_rewrite.c
+++ b/src/ngx_http_modsecurity_rewrite.c
@@ -25,10 +25,9 @@ ngx_http_modsecurity_rewrite_handler(ngx_http_request_t *r)
 {
     ngx_pool_t                   *old_pool;
     ngx_http_modsecurity_ctx_t   *ctx;
-    ngx_http_modsecurity_conf_t  *mcf;
 
-    mcf = ngx_http_get_module_loc_conf(r, ngx_http_modsecurity_module);
-    if (mcf == NULL || mcf->enable != 1) {
+    if (ngx_http_modsecurity_is_enabled(r) != NGX_OK)
+    {
         dd("ModSecurity not enabled... returning");
         return NGX_DECLINED;
     }


### PR DESCRIPTION
This updates the `modsecurity` directive to allow the use of variables in the directive value.

We use it so that ModSecurity-nginx can be enabled or disabled per request based on variables set via [nginx map](https://nginx.org/en/docs/http/ngx_http_map_module.html#map) which in turn can look at various aspects of a request to render an "on" or "off" value.